### PR TITLE
UFMJ-4 setup of FileHandlingException.java to handle all exception thrown by this framework

### DIFF
--- a/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/file_handling_exceptions/FileHandlingException.java
+++ b/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/file_handling_exceptions/FileHandlingException.java
@@ -1,0 +1,6 @@
+package com.million_projects.universal_file_manager.file_handling_exceptions;
+
+public class FileHandlingException extends RuntimeException{
+    public FileHandlingException(String message) { super(message); }
+    public FileHandlingException(String message, Throwable cause) { super(message, cause); }
+}

--- a/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/file_handling_exceptions/NoSuitableFileHandlerException.java
+++ b/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/file_handling_exceptions/NoSuitableFileHandlerException.java
@@ -1,0 +1,5 @@
+package com.million_projects.universal_file_manager.file_handling_exceptions;
+
+public class NoSuitableFileHandlerException extends FileHandlingException{
+    public NoSuitableFileHandlerException(String message) { super(message); }
+}


### PR DESCRIPTION
UFMJ-4 setup of FileHandlingException.java and NoSuitableFileHandlerException.java that extends from RuntimeException (will be used to handle all exception thrown by this framework)