### PR TITLE
UFMJ-6 add generic File Handlers for each File Format and Data Formats (object, txt, binary) and a base UniversalFileHandler Interface

### DIFF
--- a/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/BinaryFileHandler.java
+++ b/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/BinaryFileHandler.java
@@ -1,0 +1,11 @@
+package com.million_projects.universal_file_manager.generic_file_handlers;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+// IMAGE, AUDIO, VIDEO
+public interface BinaryFileHandler extends UniversalFileHandler{
+    CompletableFuture<byte[]> readBytes(ExecutorService executor, File file);
+    CompletableFuture<Void> writeBytes(ExecutorService executor, File file, byte[] dataToWrite);
+}

--- a/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/ObjectFileHandler.java
+++ b/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/ObjectFileHandler.java
@@ -1,0 +1,21 @@
+package com.million_projects.universal_file_manager.generic_file_handlers;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+// JSON, CSV, XML, YAML, PROPERTIES, PROTOCOL_BUFFER
+public interface ObjectFileHandler extends UniversalFileHandler {
+    public <T> CompletableFuture<T> readObject(ExecutorService executor, File fileToRead, Class<T> classToDeserialize);
+    public CompletableFuture<Void> writeObject(ExecutorService executor, File fileToWrite, Object objectToWrite);
+}
+
+/*
+ * For JSON, you use new ObjectMapper().
+
+For XML, you use new XmlMapper() (which extends ObjectMapper).
+
+For YAML, you use new YAMLMapper() (which extends ObjectMapper).
+
+For Properties, you use new JavaPropsMapper() (which extends ObjectMapper).
+ */

--- a/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/TextFileHandler.java
+++ b/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/TextFileHandler.java
@@ -1,0 +1,12 @@
+package com.million_projects.universal_file_manager.generic_file_handlers;
+
+import java.io.File;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+// TXT, MARKDOWN, LOGS
+public interface TextFileHandler extends UniversalFileHandler{
+    CompletableFuture<String> readText(ExecutorService executor, File fileToRead);
+    CompletableFuture<Void> writeText(ExecutorService executor, File fileToWrite, String contentToWrite, StandardOpenOption standardOpenOption);
+}

--- a/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/UniversalFileHandler.java
+++ b/universal-file-manager/src/main/java/com/million_projects/universal_file_manager/generic_file_handlers/UniversalFileHandler.java
@@ -1,0 +1,11 @@
+package com.million_projects.universal_file_manager.generic_file_handlers;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+public interface UniversalFileHandler {
+    public boolean canHandle(File file);
+    public <T> CompletableFuture<T> read(ExecutorService executor, File fileToRead, Object option);
+    public CompletableFuture<Void> write(ExecutorService executor, File fileToWrite, Object contentToWrite, Object option); 
+}


### PR DESCRIPTION
UFMJ-6 add generic File handler: UniversalFileHandler.java, ObjectFileHandler.java, TextFileHandler.java & BinaryFileHandler.java to git. Generic File Handlers for each File Format and Data Formats (object, txt, binary) and a base UniversalFileHandler Interface.